### PR TITLE
Remove old Wine PPA, if one is present

### DIFF
--- a/gameready.sh
+++ b/gameready.sh
@@ -11,6 +11,8 @@ fi
 echo "Installing WINE"
 sudo dpkg --add-architecture i386
 sudo wget -nc -O /usr/share/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+# REMOVE PREVIOUS WINE PPA IF PRESENT
+sudo rm /etc/apt/sources.list.d/winehq*
 # GET UBUNTU VERSION
 ubuntuVersion=$(lsb_release -sc)
 sudo wget -nc -P /etc/apt/sources.list.d/ "https://dl.winehq.org/wine-builds/ubuntu/dists/${ubuntuVersion}/winehq-${ubuntuVersion}.sources"


### PR DESCRIPTION
With each Ubuntu point release, Wine moves to a new PPA. This line will remove any existing Wine PPAs before the script then adds the one corresponding to the user's current Ubuntu version.

In theory, this would mean that running this script again after an Ubuntu update will automatically swap the user to the latest Wine PPA each time. Though I'm not sure how the rest of the script would behave with all the other software already being installed, you may want to copy this into a separate updater script perhaps.