### PR TITLE
Skips confirmation on Xanmod Install

### DIFF
--- a/gameready.sh
+++ b/gameready.sh
@@ -53,7 +53,7 @@ if zenity --question --title="Install Xanmod Kernel?" --text="Your current kerne
 	{
 		echo 'deb http://deb.xanmod.org releases main' | sudo tee /etc/apt/sources.list.d/xanmod-kernel.list
 		wget -qO - https://dl.xanmod.org/gpg.key | sudo apt-key --keyring /etc/apt/trusted.gpg.d/xanmod-kernel.gpg add -
-		sudo apt update && sudo apt install linux-xanmod
+		sudo apt update && sudo apt install linux-xanmod -y
 		zenity --info --title="Success" --text="Xanmod kernel installed! Make sure to reboot after all the script finishes its work."
 	}
 fi


### PR DESCRIPTION
On the command to install xanmod, it waits for user confirmation at the terminal, which doesn't seem to fit on an automated script some messages are shown with GUI.

While xanmod install will download huge file and will ask for user confirmation I appended -y so xanmod will install without confirmation on terminal