### PR TITLE
Refactor OS detection for Debian and Ubuntu to use regex matching

### DIFF
--- a/gameready.sh
+++ b/gameready.sh
@@ -25,7 +25,7 @@ then
     exit 0
     
     # FOR DEBIAN AND UBUNTU
-elif [[ $ID_LIKE = debian ]] || [[ $ID_LIKE = ubuntu ]];
+elif [[ $ID_LIKE =~ (debian|ubuntu) ]];
 then
     # RUN GAMEREADY-DEBIAN.SH
     echo -e "\n\n${RED}<-- Running gameready-ubuntu.sh -->${ENDCOLOR}"


### PR DESCRIPTION
For my Linux Mint the following command gives the following result:
```bash
~$ source /etc/os-release
~$ echo $ID_LIKE
ubuntu debian
```

in this case the ubuntu or debian if statement is false since it's not "ubuntu" or "debian" but "ubuntu debian" all together...

so I modified the detection code to use regex, to find these to words in any kind of combination.
so it does in case of my Linux Mint